### PR TITLE
Fix options flow static method

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -28,8 +28,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         })
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
 
+    @staticmethod
     @callback
-    def async_get_options_flow(self, config_entry):
+    def async_get_options_flow(config_entry):
         return OptionsFlowHandler(config_entry)
 
 


### PR DESCRIPTION
## Summary
- make async_get_options_flow a static method without self to avoid options panel exception

## Testing
- `python -m py_compile custom_components/ofoehn_poolpilot/config_flow.py`
- `python - <<'PY'
import types, sys, os, importlib.util

vol = types.ModuleType("voluptuous")
class Schema:
    def __init__(self, *args, **kwargs):
        pass
vol.Schema = Schema
vol.Required = lambda *args, **kwargs: None
vol.Optional = lambda *args, **kwargs: None
vol.In = lambda x: x
sys.modules['voluptuous'] = vol

homeassistant = types.ModuleType("homeassistant")
config_entries = types.ModuleType("homeassistant.config_entries")
class ConfigFlow:
    def __init_subclass__(cls, **kwargs):
        pass
class OptionsFlow:
    pass
config_entries.ConfigFlow = ConfigFlow
config_entries.OptionsFlow = OptionsFlow
homeassistant.config_entries = config_entries
sys.modules['homeassistant'] = homeassistant
sys.modules['homeassistant.config_entries'] = config_entries
core = types.ModuleType("homeassistant.core")
def callback(func):
    return func
core.callback = callback
homeassistant.core = core
sys.modules['homeassistant.core'] = core

package_cc = types.ModuleType("custom_components")
package_cc.__path__ = [os.path.join(os.getcwd(), "custom_components")]
sys.modules["custom_components"] = package_cc
package = types.ModuleType("custom_components.ofoehn_poolpilot")
package.__path__ = [os.path.join(os.getcwd(), "custom_components", "ofoehn_poolpilot")]
sys.modules["custom_components.ofoehn_poolpilot"] = package

spec = importlib.util.spec_from_file_location(
    "custom_components.ofoehn_poolpilot.config_flow",
    os.path.join(os.getcwd(), "custom_components", "ofoehn_poolpilot", "config_flow.py"),
    submodule_search_locations=package.__path__
)
module = importlib.util.module_from_spec(spec)
sys.modules[spec.name] = module
spec.loader.exec_module(module)

result = module.ConfigFlow.async_get_options_flow(object())
print("Result type:", type(result).__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb5db5c27c8323bda7d5aed6a3417a