### PR TITLE
Use async_get_clientsession for session creation

### DIFF
--- a/custom_components/ofoehn_poolpilot/__init__.py
+++ b/custom_components/ofoehn_poolpilot/__init__.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from aiohttp import ClientSession
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, PLATFORMS, SCAN_INTERVAL
@@ -19,7 +20,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    session: ClientSession = hass.helpers.aiohttp_client.async_get_clientsession()
+    session: ClientSession = async_get_clientsession(hass)
 
     api = OFoehnApi(
         host=entry.data["host"],


### PR DESCRIPTION
## Summary
- import `async_get_clientsession` from homeassistant helper
- use `async_get_clientsession` for session initialization

## Testing
- `pytest`
- `python -m py_compile custom_components/ofoehn_poolpilot/__init__.py`
- `python - <<'PY'
import importlib
importlib.import_module('custom_components.ofoehn_poolpilot')
PY` *(fails: ModuleNotFoundError: No module named 'aiohttp'; `pip install aiohttp` failed due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5db0a3348323b477b787658f5d6e