### PR TITLE
Expose full raw responses via extra attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Version **v0.2.1** — Ajout de l'**authentification**: NONE / BASIC / QUERY / C
 ## ✨ Fonctionnalités
 - Entité **Climate** (OFF/AUTO/CHAUD/FROID, consigne pas de 0,5 °C)
 - Capteurs : **Eau In / Eau Out / Air**
+- Capteurs *Raw* : **Super / Accueil / Reg** (valeur affichée limitée à 255 caractères, réponse complète dans l'attribut `raw`)
 - Switchs : **PAC – Alimentation** & **Éclairage**
 - **Config Flow** (IP/Port + Auth)
 - Exemples Lovelace (`examples/`)

--- a/custom_components/ofoehn_poolpilot/sensor.py
+++ b/custom_components/ofoehn_poolpilot/sensor.py
@@ -70,4 +70,8 @@ class RawSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self):
-        return self.coordinator.data.get(self._key)
+        value = self.coordinator.data.get(self._key)
+        self._attr_extra_state_attributes = {"raw": value}
+        if value is None:
+            return None
+        return value[:255]


### PR DESCRIPTION
## Summary
- Limit RawSensor native value to 255 characters and store full response in `raw` attribute
- Document raw attribute behavior in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdf19d5c88323a009cf9aaf10e2c1