### PR TITLE
Add configurable timeout to OFoehn API

### DIFF
--- a/custom_components/ofoehn_poolpilot/__init__.py
+++ b/custom_components/ofoehn_poolpilot/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, PLATFORMS, SCAN_INTERVAL
+from .const import DOMAIN, PLATFORMS, SCAN_INTERVAL, DEFAULT_TIMEOUT
 from .coordinator import OFoehnApi, OFoehnCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         login_method=entry.data.get("login_method", "POST"),
         user_field=entry.data.get("user_field", "user"),
         pass_field=entry.data.get("pass_field", "pass"),
+        timeout=entry.data.get("timeout", DEFAULT_TIMEOUT),
     )
 
     coordinator = OFoehnCoordinator(

--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
-from .const import DOMAIN, DEFAULT_PORT, AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE, DEFAULT_INDEX
+from .const import (
+    DOMAIN,
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    AUTH_NONE,
+    AUTH_BASIC,
+    AUTH_QUERY,
+    AUTH_COOKIE,
+    DEFAULT_INDEX,
+)
 
 AUTH_OPTIONS = [AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE]
 
@@ -25,6 +34,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional("login_method", default="POST"): vol.In(["GET", "POST"]),
             vol.Optional("user_field", default="user"): str,
             vol.Optional("pass_field", default="pass"): str,
+            vol.Optional("timeout", default=DEFAULT_TIMEOUT): int,
         })
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
 

--- a/custom_components/ofoehn_poolpilot/const.py
+++ b/custom_components/ofoehn_poolpilot/const.py
@@ -1,5 +1,6 @@
 DOMAIN = "ofoehn_poolpilot"
 DEFAULT_PORT = 80
+DEFAULT_TIMEOUT = 10  # seconds
 PLATFORMS = ["climate", "sensor", "switch", "binary_sensor"]
 SCAN_INTERVAL = 30  # seconds
 


### PR DESCRIPTION
## Summary
- allow configuration of network request timeout
- pass configurable timeout through API requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1f5ef6a88323b6ce418c0b1dfbce