### PR TITLE
Expose full parse result of accueil

### DIFF
--- a/custom_components/ofoehn_poolpilot/coordinator.py
+++ b/custom_components/ofoehn_poolpilot/coordinator.py
@@ -208,8 +208,7 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
             "super": parse_donnees(sup),
             "accueil": parse_donnees(acc),
             "reg": parse_reg(reg),
-            "water_in": parsed_accueil.get("water_in"),
-            "setpoint": parsed_accueil.get("setpoint"),
+            **parsed_accueil,
             "indices": {
                 "water_in_idx": self.options.get("water_in_idx", DEFAULT_INDEX["water_in_idx"]),
                 "water_out_idx": self.options.get("water_out_idx", DEFAULT_INDEX["water_out_idx"]),


### PR DESCRIPTION
## Summary
- Include entire `parse_accueil_html` output in coordinator data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf522182288323ae31f7d5b8d5e207