### PR TITLE
feat: parse accueil html for sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2 — HTML Fallback
+- Parse water temperature, air temperature, voltage and internal temperature from
+  the `/accueil` HTML when numeric indices are missing.
+
 ## v0.2.1 — Auth & Examples
 - Authentification: NONE/BASIC/QUERY/COOKIE
 - Options indices DONNEE#

--- a/custom_components/ofoehn_poolpilot/sensor.py
+++ b/custom_components/ofoehn_poolpilot/sensor.py
@@ -55,8 +55,22 @@ class TempSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self):
-        idx = self.coordinator.data["indices"][self._key]
-        return self.coordinator.data["super"].get(idx)
+        idx = self.coordinator.data["indices"].get(self._key)
+        value = None
+        if idx is not None:
+            value = self.coordinator.data["super"].get(idx)
+            if value is not None:
+                return value
+        fallback_map = {
+            "water_in_idx": "water_in",
+            "water_out_idx": "water_out",
+            "air_idx": "air_temp",
+            "internal_idx": "internal_temp",
+        }
+        fb_key = fallback_map.get(self._key)
+        if fb_key:
+            return self.coordinator.data.get(fb_key)
+        return value
 
 
 class VoltageSensor(CoordinatorEntity, SensorEntity):
@@ -81,9 +95,16 @@ class VoltageSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         idx = self.coordinator.data["indices"].get(self._key)
-        if idx is None:
-            return None
-        return self.coordinator.data["super"].get(idx)
+        value = None
+        if idx is not None:
+            value = self.coordinator.data["super"].get(idx)
+            if value is not None:
+                return value
+        fallback_map = {"voltage_idx": "voltage"}
+        fb_key = fallback_map.get(self._key)
+        if fb_key:
+            return self.coordinator.data.get(fb_key)
+        return value
 
 
 class SetpointDiffSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_sensor_fallback.py
+++ b/tests/test_sensor_fallback.py
@@ -1,0 +1,107 @@
+import importlib.util
+import pathlib
+import types
+import sys
+
+fake_aiohttp = types.ModuleType("aiohttp")
+fake_aiohttp.ClientSession = object
+fake_aiohttp.BasicAuth = object
+fake_aiohttp.ClientResponseError = Exception
+sys.modules["aiohttp"] = fake_aiohttp
+
+fake_ha = types.ModuleType("homeassistant")
+sys.modules["homeassistant"] = fake_ha
+
+fake_core = types.ModuleType("homeassistant.core")
+fake_core.HomeAssistant = object
+sys.modules["homeassistant.core"] = fake_core
+
+fake_helpers = types.ModuleType("homeassistant.helpers")
+sys.modules["homeassistant.helpers"] = fake_helpers
+
+fake_uc = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+class _DUC:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+class _CE:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+fake_uc.DataUpdateCoordinator = _DUC
+fake_uc.CoordinatorEntity = _CE
+sys.modules["homeassistant.helpers.update_coordinator"] = fake_uc
+
+fake_sensor_mod = types.ModuleType("homeassistant.components.sensor")
+fake_sensor_mod.SensorEntity = object
+sys.modules["homeassistant.components.sensor"] = fake_sensor_mod
+
+fake_const = types.ModuleType("homeassistant.const")
+fake_const.UnitOfTemperature = types.SimpleNamespace(CELSIUS="°C")
+fake_const.UnitOfElectricPotential = types.SimpleNamespace(VOLT="V")
+sys.modules["homeassistant.const"] = fake_const
+
+fake_entity = types.ModuleType("homeassistant.helpers.entity")
+
+class _EC:
+    DIAGNOSTIC = "diagnostic"
+
+fake_entity.EntityCategory = _EC
+sys.modules["homeassistant.helpers.entity"] = fake_entity
+
+base_path = pathlib.Path(__file__).resolve().parents[1]
+custom_components_path = base_path / "custom_components"
+package_cc = types.ModuleType("custom_components")
+package_cc.__path__ = [str(custom_components_path)]
+sys.modules.setdefault("custom_components", package_cc)
+
+package_pp = types.ModuleType("custom_components.ofoehn_poolpilot")
+package_pp.__path__ = [str(custom_components_path / "ofoehn_poolpilot")]
+sys.modules.setdefault("custom_components.ofoehn_poolpilot", package_pp)
+
+const_path = custom_components_path / "ofoehn_poolpilot" / "const.py"
+const_spec = importlib.util.spec_from_file_location("custom_components.ofoehn_poolpilot.const", const_path)
+const_module = importlib.util.module_from_spec(const_spec)
+const_spec.loader.exec_module(const_module)
+sys.modules["custom_components.ofoehn_poolpilot.const"] = const_module
+
+sensor_path = custom_components_path / "ofoehn_poolpilot" / "sensor.py"
+sensor_spec = importlib.util.spec_from_file_location("custom_components.ofoehn_poolpilot.sensor", sensor_path)
+sensor_module = importlib.util.module_from_spec(sensor_spec)
+sensor_spec.loader.exec_module(sensor_module)
+
+TempSensor = sensor_module.TempSensor
+VoltageSensor = sensor_module.VoltageSensor
+
+
+class DummyCoordinator:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_temp_sensor_fallback():
+    coord = DummyCoordinator(
+        {
+            "indices": {"water_in_idx": 1},
+            "super": {},
+            "water_in": 28.6,
+        }
+    )
+    sensor = TempSensor(coord, "host", "entry", key="water_in_idx", name="Eau In")
+    assert sensor.native_value == 28.6
+
+
+def test_voltage_sensor_fallback():
+    coord = DummyCoordinator(
+        {
+            "indices": {"voltage_idx": 1},
+            "super": {},
+            "voltage": 230.0,
+        }
+    )
+    sensor = VoltageSensor(coord, "host", "entry", key="voltage_idx", name="Tension")
+    assert sensor.native_value == 230.0


### PR DESCRIPTION
## Summary
- fallback to values parsed from `/accueil` HTML when DONNEE indices missing
- document HTML fallback in changelog
- test temp and voltage sensor fallbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c031807a948323a55ddaae0fa089c2