### PR TITLE
refactor: centralize device info

### DIFF
--- a/custom_components/ofoehn_poolpilot/binary_sensor.py
+++ b/custom_components/ofoehn_poolpilot/binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
+from .helpers import device_info_for_host
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -32,12 +33,7 @@ class ConnectivityBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def is_on(self) -> bool:
@@ -61,12 +57,7 @@ class PumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def is_on(self) -> bool:
@@ -86,12 +77,7 @@ class HeatingBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/ofoehn_poolpilot/climate.py
+++ b/custom_components/ofoehn_poolpilot/climate.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
+from .helpers import device_info_for_host
 
 SUPPORTED_HVAC = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
 
@@ -35,12 +36,7 @@ class OFoehnClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     def _is_power_on(self):
         idx = self.coordinator.data["indices"].get("power_idx")

--- a/custom_components/ofoehn_poolpilot/helpers.py
+++ b/custom_components/ofoehn_poolpilot/helpers.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .const import DOMAIN
+
+
+def device_info_for_host(host: str) -> dict:
+    """Return device information for a given host."""
+    return {
+        "identifiers": {(DOMAIN, host)},
+        "name": "O'Foehn PoolPilot",
+        "manufacturer": "O'Foehn",
+        "model": "PoolPilot",
+    }

--- a/custom_components/ofoehn_poolpilot/sensor.py
+++ b/custom_components/ofoehn_poolpilot/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
+from .helpers import device_info_for_host
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -46,12 +47,7 @@ class TempSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def native_value(self):
@@ -85,12 +81,7 @@ class VoltageSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def native_value(self):
@@ -118,12 +109,7 @@ class SetpointDiffSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def native_value(self):
@@ -146,12 +132,7 @@ class RegTextSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def native_value(self):
@@ -170,12 +151,7 @@ class RawSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def native_value(self):

--- a/custom_components/ofoehn_poolpilot/switch.py
+++ b/custom_components/ofoehn_poolpilot/switch.py
@@ -5,6 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
+from .helpers import device_info_for_host
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -24,12 +25,7 @@ class PowerSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def is_on(self):
@@ -57,12 +53,7 @@ class PoolLightSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._host)},
-            "name": "O'Foehn PoolPilot",
-            "manufacturer": "O'Foehn",
-            "model": "PoolPilot",
-        }
+        return device_info_for_host(self._host)
 
     @property
     def is_on(self):


### PR DESCRIPTION
## Summary
- create `device_info_for_host` helper
- use helper for device info across climate, binary_sensor, switch and sensor entities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c03630ab948323a2b4d025bf624a71