### PR TITLE
Limit config flow host discovery runtime to avoid 504 timeouts

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -166,7 +166,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         defaults = dict(user_input or {})
         if not defaults and not self._detected_hosts:
-            self._detected_hosts = await self._async_discover_hosts(DEFAULT_PORT)
+            try:
+                self._detected_hosts = await asyncio.wait_for(
+                    self._async_discover_hosts(DEFAULT_PORT), timeout=8
+                )
+            except TimeoutError:
+                self._detected_hosts = []
+            except Exception:
+                self._detected_hosts = []
         if self._detected_hosts and not defaults.get(CONF_HOST):
             defaults[CONF_HOST] = self._detected_hosts[0]
 


### PR DESCRIPTION
### Motivation
- The config flow could block page load while performing LAN host discovery, causing gateway/proxy 504 timeouts when scanning networks is slow or blocked. 

### Description
- Wrap the automatic host discovery call in `async_step_user` with `asyncio.wait_for(..., timeout=8)` to cap the discovery runtime. 
- Add graceful fallback on timeout or any discovery exception by setting the detected-host list to an empty list. 
- Preserve existing logic that pre-fills the `host` default from `self._detected_hosts` when discovery succeeds (file `custom_components/ofoehn_poolpilot/config_flow.py`).

### Testing
- Ran `python -m compileall custom_components/ofoehn_poolpilot/config_flow.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d06642bc8323982936ff779f7507)