### PR TITLE
Add discovery timeout to config flow to avoid startup spinner loop

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -29,6 +29,7 @@ DISCOVERY_TIMEOUT = 1
 DISCOVERY_CONCURRENCY = 32
 DISCOVERY_FALLBACK_PREFIX = 24
 DISCOVERY_MAX_HOSTS = 256
+DISCOVERY_TOTAL_TIMEOUT = 8
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -166,7 +167,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         defaults = dict(user_input or {})
         if not defaults and not self._detected_hosts:
-            self._detected_hosts = await self._async_discover_hosts(DEFAULT_PORT)
+            try:
+                self._detected_hosts = await asyncio.wait_for(
+                    self._async_discover_hosts(DEFAULT_PORT),
+                    timeout=DISCOVERY_TOTAL_TIMEOUT,
+                )
+            except (TimeoutError, Exception):
+                self._detected_hosts = []
         if self._detected_hosts and not defaults.get(CONF_HOST):
             defaults[CONF_HOST] = self._detected_hosts[0]
 


### PR DESCRIPTION
### Motivation
- Prevent the config flow UI from blocking indefinitely during local host auto-discovery when LAN probing is slow or unavailable by enforcing a global discovery timeout.

### Description
- Add `DISCOVERY_TOTAL_TIMEOUT = 8` and wrap the call to `_async_discover_hosts` with `asyncio.wait_for(..., timeout=DISCOVERY_TOTAL_TIMEOUT)` in `custom_components/ofoehn_poolpilot/config_flow.py`.
- Catch `TimeoutError` and other exceptions and fall back to an empty detected-hosts list so the setup form remains responsive instead of spinning.

### Testing
- Ran `python -m py_compile custom_components/ofoehn_poolpilot/config_flow.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d03836b0832380dd3149bf5c10a1)