### PR TITLE
Avoid config flow 504 by removing LAN-wide discovery on form load

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address
 from typing import Any
 
 import voluptuous as vol
@@ -26,9 +26,6 @@ from .const import (
 
 AUTH_OPTIONS = [AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE]
 DISCOVERY_TIMEOUT = 1
-DISCOVERY_CONCURRENCY = 32
-DISCOVERY_FALLBACK_PREFIX = 24
-DISCOVERY_MAX_HOSTS = 256
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -102,47 +99,27 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return host
         return None
 
-    async def _async_discover_hosts(self, port: int) -> list[str]:
-        adapters = await network.async_get_adapters(self.hass)
-        candidates: list[str] = []
-        seen: set[str] = set()
 
+    async def _async_get_local_ipv4(self) -> str | None:
+        adapters = await network.async_get_adapters(self.hass)
         for adapter in adapters:
             for ipv4 in adapter.get("ipv4", []):
                 local_ip = ip_address(ipv4["address"])
                 if local_ip.is_loopback or local_ip.is_link_local or not local_ip.is_private:
                     continue
+                return str(local_ip)
+        return None
 
-                prefix = ipv4["network_prefix"]
-                if prefix < DISCOVERY_FALLBACK_PREFIX:
-                    scan_network = ip_network(f"{local_ip}/{DISCOVERY_FALLBACK_PREFIX}", strict=False)
-                else:
-                    scan_network = ip_network(f"{local_ip}/{prefix}", strict=False)
-
-                if scan_network.num_addresses > DISCOVERY_MAX_HOSTS:
-                    scan_network = ip_network(f"{local_ip}/{DISCOVERY_FALLBACK_PREFIX}", strict=False)
-
-                for candidate in scan_network.hosts():
-                    host = str(candidate)
-                    if candidate == local_ip or host in seen:
-                        continue
-                    seen.add(host)
-                    candidates.append(host)
-
-        if not candidates:
+    async def _async_discover_hosts(self, port: int) -> list[str]:
+        local_ip = await self._async_get_local_ipv4()
+        if not local_ip:
             return []
 
-        semaphore = asyncio.Semaphore(DISCOVERY_CONCURRENCY)
-        found: list[str] = []
+        detected = await self._async_probe_host(local_ip, port)
+        if detected:
+            return [detected]
+        return []
 
-        async def _probe(candidate: str) -> None:
-            async with semaphore:
-                detected = await self._async_probe_host(candidate, port)
-                if detected is not None:
-                    found.append(detected)
-
-        await asyncio.gather(*(_probe(candidate) for candidate in candidates))
-        return sorted(found, key=lambda item: tuple(int(part) for part in item.split(".")))
 
     async def async_step_user(self, user_input=None):
         errors = {}
@@ -165,10 +142,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=f"O'Foehn ({user_input[CONF_HOST]})", data=data)
 
         defaults = dict(user_input or {})
-        if not defaults and not self._detected_hosts:
-            self._detected_hosts = await self._async_discover_hosts(DEFAULT_PORT)
-        if self._detected_hosts and not defaults.get(CONF_HOST):
-            defaults[CONF_HOST] = self._detected_hosts[0]
+        if not defaults:
+            local_ip = await self._async_get_local_ipv4()
+            if local_ip and not defaults.get(CONF_HOST):
+                defaults[CONF_HOST] = local_ip
+
+            if not self._detected_hosts:
+                try:
+                    self._detected_hosts = await asyncio.wait_for(
+                        self._async_discover_hosts(DEFAULT_PORT), timeout=2
+                    )
+                except TimeoutError:
+                    self._detected_hosts = []
+                except Exception:
+                    self._detected_hosts = []
+
+            if self._detected_hosts and not defaults.get(CONF_HOST):
+                defaults[CONF_HOST] = self._detected_hosts[0]
 
         return self.async_show_form(
             step_id="user",


### PR DESCRIPTION
### Motivation
- The config flow could block page rendering when performing a LAN-wide subnet scan, causing `504 Gateway Time-out` behind some proxies. 
- The goal is to make the form render quickly while still offering a helpful host prefill when possible.

### Description
- Removed the heavy LAN-wide subnet scan and related constants/imports, replacing it with a lightweight local-IP lookup using a new `_async_get_local_ipv4()` helper. 
- Simplified `_async_discover_hosts()` to only probe the local IPv4 address instead of scanning the whole subnet. 
- Updated `async_step_user` to immediately prefill the `host` field with the local IPv4 when available, and to keep a short guarded discovery attempt using `asyncio.wait_for(..., timeout=2)` as a non-blocking fallback. 
- Kept discovery failures and timeouts handled gracefully by falling back to an empty detected-hosts list so the UI still renders.

### Testing
- Ran `python -m compileall custom_components/ofoehn_poolpilot/config_flow.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d06642bc8323982936ff779f7507)