### PR TITLE
Remove automatic host detection from ConfigFlow

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -27,9 +27,6 @@ AUTH_OPTIONS = [AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE]
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
-    def __init__(self) -> None:
-        self._detected_hosts: list[str] = []
-
     def _build_user_schema(self, defaults: dict[str, Any] | None = None) -> vol.Schema:
         defaults = defaults or {}
         return vol.Schema(
@@ -102,15 +99,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         defaults = dict(user_input or {})
         if not defaults and not defaults.get(CONF_HOST):
             defaults[CONF_HOST] = ""
-        self._detected_hosts = []
-
         return self.async_show_form(
             step_id="user",
             data_schema=self._build_user_schema(defaults),
             errors=errors,
-            description_placeholders={
-                "detected_hosts": ", ".join(self._detected_hosts) if self._detected_hosts else "-"
-            },
         )
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- The automatic host detection state and UI hinting added complexity and caused configuration to block on connectivity, so the setup should remain manual.

### Description
- Remove the `_detected_hosts` state and the `description_placeholders` usage from the `ConfigFlow` and simplify the `async_step_user` form to only call `async_show_form` with the `data_schema` and `errors`.

### Testing
- No automated tests were executed for this small config-flow UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e9988a348323ac13456996e34fe8)