### PR TITLE
Simplify config flow, enforce single instance, and refine coordinator retry logic

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNA
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .coordinator import OFoehnApi, parse_accueil_html, parse_donnees, parse_super_values
+from .coordinator import OFoehnApi, parse_donnees
 
 from .const import (
     DOMAIN,
@@ -27,9 +27,6 @@ AUTH_OPTIONS = [AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE]
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
-    def __init__(self) -> None:
-        self._detected_hosts: list[str] = []
-
     def _build_user_schema(self, defaults: dict[str, Any] | None = None) -> vol.Schema:
         defaults = defaults or {}
         return vol.Schema(
@@ -47,70 +44,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-    async def _async_validate_input(self, user_input: dict[str, Any]) -> dict[str, Any]:
-        session = async_get_clientsession(self.hass)
-        api = OFoehnApi(
-            host=user_input[CONF_HOST],
-            port=user_input.get(CONF_PORT, DEFAULT_PORT),
-            session=session,
-            auth_mode=user_input.get("auth_mode", AUTH_NONE),
-            username=user_input.get(CONF_USERNAME),
-            password=user_input.get(CONF_PASSWORD),
-            login_path=user_input.get("login_path", "/login.cgi"),
-            login_method=user_input.get("login_method", "POST"),
-            user_field=user_input.get("user_field", "user"),
-            pass_field=user_input.get("pass_field", "pass"),
-            timeout=user_input.get("timeout", DEFAULT_TIMEOUT),
-        )
-
-        raw_super = await api.read_super()
-        raw_accueil = await api.read_accueil()
-
-        parsed_super = parse_super_values(raw_super)
-        parsed_accueil = parse_accueil_html(raw_accueil)
-        if not parsed_super and not parsed_accueil:
-            raise ValueError("Not an O'Foehn payload")
-
-        return {
-            "serial_number": parsed_accueil.get("serial_number"),
-            "mac_address": parsed_accueil.get("mac_address"),
-            "module_name": parsed_accueil.get("module_name"),
-        }
-
-
-
     async def async_step_user(self, user_input=None):
         errors = {}
-        if user_input is not None:
-            try:
-                info = await self._async_validate_input(user_input)
-            except Exception:
-                errors["base"] = "cannot_connect"
-            else:
-                unique_id = info.get("serial_number") or info.get("mac_address")
-                if unique_id:
-                    await self.async_set_unique_id(str(unique_id))
-                    self._abort_if_unique_id_configured()
+        if self._async_current_entries() and user_input is None:
+            return self.async_abort(reason="single_instance_allowed")
 
-                data = dict(user_input)
-                if info.get("serial_number"):
-                    data["serial_number"] = info["serial_number"]
-                if info.get("mac_address"):
-                    data["mac_address"] = info["mac_address"]
-                return self.async_create_entry(title=f"O'Foehn ({user_input[CONF_HOST]})", data=data)
+        if user_input is not None:
+            if self._async_current_entries():
+                return self.async_abort(reason="single_instance_allowed")
+            unique_id = str(user_input[CONF_HOST]).strip().lower()
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=f"O'Foehn ({user_input[CONF_HOST]})", data=dict(user_input))
 
         defaults = dict(user_input or {})
         if not defaults and not defaults.get(CONF_HOST):
             defaults[CONF_HOST] = ""
-        self._detected_hosts = []
-
         return self.async_show_form(
             step_id="user",
             data_schema=self._build_user_schema(defaults),
             errors=errors,
-            description_placeholders={
-                "detected_hosts": ", ".join(self._detected_hosts) if self._detected_hosts else "-"
-            },
         )
 
     @staticmethod

--- a/custom_components/ofoehn_poolpilot/coordinator.py
+++ b/custom_components/ofoehn_poolpilot/coordinator.py
@@ -63,9 +63,10 @@ TEMP_PAIR_RE = re.compile(
     re.IGNORECASE,
 )
 
-READ_RETRIES = 2
+READ_RETRIES = 0
 READ_RETRY_DELAY = 0.75
 INTER_REQUEST_DELAY = 0.25
+RETRYABLE_HTTP_STATUSES = {408, 425, 429, 500, 502, 503, 504}
 
 
 def clean_html_text(raw: str | None) -> str:
@@ -397,7 +398,7 @@ class OFoehnApi:
                     await self._maybe_login(force=True)
                     auth_retry_done = True
                     continue
-                if method != "GET" or attempt >= retries:
+                if method != "GET" or attempt >= retries or err.status not in RETRYABLE_HTTP_STATUSES:
                     raise
                 attempt += 1
                 delay = READ_RETRY_DELAY * attempt

--- a/custom_components/ofoehn_poolpilot/translations/en.json
+++ b/custom_components/ofoehn_poolpilot/translations/en.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Connect to O'Foehn heat pump",
-        "description": "Enter the IP address and choose the authentication mode if required. Local auto-detection: {detected_hosts}.",
+        "description": "Enter the IP address and choose the authentication mode if required.",
         "data": {
           "host": "IP address",
           "port": "Port",
@@ -20,7 +20,8 @@
       }
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "single_instance_allowed": "Only one O'Foehn PoolPilot configuration is allowed. Edit or remove the existing entry."
     },
     "error": {
       "cannot_connect": "Cannot connect to the heat pump.",

--- a/custom_components/ofoehn_poolpilot/translations/fr.json
+++ b/custom_components/ofoehn_poolpilot/translations/fr.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Connexion à la PAC O'Foehn",
-        "description": "Entrez l'adresse IP et choisissez le mode d'authentification si nécessaire. Détection automatique locale: {detected_hosts}.",
+        "description": "Entrez l'adresse IP et choisissez le mode d'authentification si nécessaire.",
         "data": {
           "host": "Adresse IP",
           "port": "Port",
@@ -20,7 +20,8 @@
       }
     },
     "abort": {
-      "already_configured": "Cet appareil est déjà configuré."
+      "already_configured": "Cet appareil est déjà configuré.",
+      "single_instance_allowed": "Une seule configuration O'Foehn PoolPilot est autorisée. Modifiez ou supprimez l'entrée existante."
     },
     "error": {
       "cannot_connect": "Connexion à la PAC impossible.",


### PR DESCRIPTION
### Motivation
- Reduce noisy network probing during configuration by removing device HTML validation from the user config flow and making the host the unique identifier. 
- Prevent multiple configurations of the same device by enforcing a single-instance policy in the config flow. 
- Make HTTP retry behavior in the coordinator more selective and reduce automatic retry attempts to avoid spurious retries for non-retryable responses. 

### Description
- Update `config_flow.py` to remove autodetection and payload validation, set the unique ID to a normalized `host` value via `async_set_unique_id`, abort when an entry already exists, and remove the `detected_hosts`/description placeholder logic. 
- Remove unused imports of `parse_accueil_html` and `parse_super_values` from the config flow. 
- Change coordinator retry behavior by setting `READ_RETRIES` to `0`, adding a `RETRYABLE_HTTP_STATUSES` set, and only retrying GET requests for retryable HTTP statuses. 
- Update translations (`en.json` and `fr.json`) to remove the detected hosts text from the config description and add an abort message for the `single_instance_allowed` reason. 

### Testing
- Ran the repository's automated unit tests covering the config flow and coordinator logic, and they completed successfully. 
- Ran static checks (`flake8`/`mypy`) against the changed files, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e9988a348323ac13456996e34fe8)