### PR TITLE
Simplify config flow (single instance + reauth) and tighten HTTP retry behavior

### DIFF
--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNA
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .coordinator import OFoehnApi, parse_accueil_html, parse_donnees, parse_super_values
+from .coordinator import OFoehnApi, parse_donnees
 
 from .const import (
     DOMAIN,
@@ -27,9 +27,6 @@ AUTH_OPTIONS = [AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE]
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
-    def __init__(self) -> None:
-        self._detected_hosts: list[str] = []
-
     def _build_user_schema(self, defaults: dict[str, Any] | None = None) -> vol.Schema:
         defaults = defaults or {}
         return vol.Schema(
@@ -47,70 +44,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-    async def _async_validate_input(self, user_input: dict[str, Any]) -> dict[str, Any]:
-        session = async_get_clientsession(self.hass)
-        api = OFoehnApi(
-            host=user_input[CONF_HOST],
-            port=user_input.get(CONF_PORT, DEFAULT_PORT),
-            session=session,
-            auth_mode=user_input.get("auth_mode", AUTH_NONE),
-            username=user_input.get(CONF_USERNAME),
-            password=user_input.get(CONF_PASSWORD),
-            login_path=user_input.get("login_path", "/login.cgi"),
-            login_method=user_input.get("login_method", "POST"),
-            user_field=user_input.get("user_field", "user"),
-            pass_field=user_input.get("pass_field", "pass"),
-            timeout=user_input.get("timeout", DEFAULT_TIMEOUT),
-        )
-
-        raw_super = await api.read_super()
-        raw_accueil = await api.read_accueil()
-
-        parsed_super = parse_super_values(raw_super)
-        parsed_accueil = parse_accueil_html(raw_accueil)
-        if not parsed_super and not parsed_accueil:
-            raise ValueError("Not an O'Foehn payload")
-
-        return {
-            "serial_number": parsed_accueil.get("serial_number"),
-            "mac_address": parsed_accueil.get("mac_address"),
-            "module_name": parsed_accueil.get("module_name"),
-        }
-
-
-
     async def async_step_user(self, user_input=None):
         errors = {}
+        existing_entries = self._async_current_entries()
+        existing_entry = existing_entries[0] if existing_entries else None
+
         if user_input is not None:
-            try:
-                info = await self._async_validate_input(user_input)
-            except Exception:
-                errors["base"] = "cannot_connect"
-            else:
-                unique_id = info.get("serial_number") or info.get("mac_address")
-                if unique_id:
-                    await self.async_set_unique_id(str(unique_id))
-                    self._abort_if_unique_id_configured()
+            if existing_entry:
+                self.hass.config_entries.async_update_entry(existing_entry, data=dict(user_input))
+                await self.hass.config_entries.async_reload(existing_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+            unique_id = str(user_input[CONF_HOST]).strip().lower()
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=f"O'Foehn ({user_input[CONF_HOST]})", data=dict(user_input))
 
-                data = dict(user_input)
-                if info.get("serial_number"):
-                    data["serial_number"] = info["serial_number"]
-                if info.get("mac_address"):
-                    data["mac_address"] = info["mac_address"]
-                return self.async_create_entry(title=f"O'Foehn ({user_input[CONF_HOST]})", data=data)
-
-        defaults = dict(user_input or {})
-        if not defaults and not defaults.get(CONF_HOST):
+        defaults = dict(existing_entry.data) if existing_entry else dict(user_input or {})
+        if not defaults.get(CONF_HOST):
             defaults[CONF_HOST] = ""
-        self._detected_hosts = []
-
         return self.async_show_form(
             step_id="user",
             data_schema=self._build_user_schema(defaults),
             errors=errors,
-            description_placeholders={
-                "detected_hosts": ", ".join(self._detected_hosts) if self._detected_hosts else "-"
-            },
         )
 
     @staticmethod

--- a/custom_components/ofoehn_poolpilot/coordinator.py
+++ b/custom_components/ofoehn_poolpilot/coordinator.py
@@ -63,9 +63,10 @@ TEMP_PAIR_RE = re.compile(
     re.IGNORECASE,
 )
 
-READ_RETRIES = 2
+READ_RETRIES = 0
 READ_RETRY_DELAY = 0.75
 INTER_REQUEST_DELAY = 0.25
+RETRYABLE_HTTP_STATUSES = {408, 425, 429, 500, 502, 503, 504}
 
 
 def clean_html_text(raw: str | None) -> str:
@@ -397,7 +398,7 @@ class OFoehnApi:
                     await self._maybe_login(force=True)
                     auth_retry_done = True
                     continue
-                if method != "GET" or attempt >= retries:
+                if method != "GET" or attempt >= retries or err.status not in RETRYABLE_HTTP_STATUSES:
                     raise
                 attempt += 1
                 delay = READ_RETRY_DELAY * attempt

--- a/custom_components/ofoehn_poolpilot/manifest.json
+++ b/custom_components/ofoehn_poolpilot/manifest.json
@@ -5,9 +5,7 @@
     "@jfbrassens"
   ],
   "config_flow": true,
-  "dependencies": [
-    "network"
-  ],
+  "dependencies": [],
   "documentation": "https://github.com/austyl/ofoehn-poolpilot-ha",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/custom_components/ofoehn_poolpilot/translations/en.json
+++ b/custom_components/ofoehn_poolpilot/translations/en.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Connect to O'Foehn heat pump",
-        "description": "Enter the IP address and choose the authentication mode if required. Local auto-detection: {detected_hosts}.",
+        "description": "Enter the IP address and choose the authentication mode if required.",
         "data": {
           "host": "IP address",
           "port": "Port",
@@ -20,7 +20,9 @@
       }
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "single_instance_allowed": "Only one O'Foehn PoolPilot configuration is allowed. Edit or remove the existing entry.",
+      "reauth_successful": "Configuration updated. The integration has been reloaded."
     },
     "error": {
       "cannot_connect": "Cannot connect to the heat pump.",

--- a/custom_components/ofoehn_poolpilot/translations/fr.json
+++ b/custom_components/ofoehn_poolpilot/translations/fr.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Connexion à la PAC O'Foehn",
-        "description": "Entrez l'adresse IP et choisissez le mode d'authentification si nécessaire. Détection automatique locale: {detected_hosts}.",
+        "description": "Entrez l'adresse IP et choisissez le mode d'authentification si nécessaire.",
         "data": {
           "host": "Adresse IP",
           "port": "Port",
@@ -20,7 +20,9 @@
       }
     },
     "abort": {
-      "already_configured": "Cet appareil est déjà configuré."
+      "already_configured": "Cet appareil est déjà configuré.",
+      "single_instance_allowed": "Une seule configuration O'Foehn PoolPilot est autorisée. Modifiez ou supprimez l'entrée existante.",
+      "reauth_successful": "Configuration mise à jour. L'intégration a été rechargée."
     },
     "error": {
       "cannot_connect": "Connexion à la PAC impossible.",


### PR DESCRIPTION
### Motivation
- Simplify the integration setup by removing local autodetection and per-device discovery logic and enforce a single configuration instance.
- Support updating/re-authenticating the existing configuration entry from the config flow and reload the entry after updates.
- Reduce noisy/redundant HTTP retries and make retrying conditional on specific retryable HTTP statuses.
- Remove the `network` dependency from the manifest and update UI translations to reflect the new single-instance / reauth messaging.

### Description
- Removed the `_async_validate_input` method and related device HTML parsing import (`parse_accueil_html`, `parse_super_values`) and logic that performed live reads during setup.
- Reworked `async_step_user` to detect an existing entry via `_async_current_entries()`, update and reload it on reauth, and create new entries using a normalized host-based unique id set via `async_set_unique_id`; removed the `detected_hosts` placeholder and description placeholder usage.
- In `coordinator.py` changed `READ_RETRIES` from `2` to `0`, added a `RETRYABLE_HTTP_STATUSES` set, and adjusted the read retry logic to only retry GET requests and when the HTTP status is in `RETRYABLE_HTTP_STATUSES`.
- Removed the `network` dependency from `manifest.json` and updated translation files (`translations/en.json` and `translations/fr.json`) to remove the autodetection text and add `single_instance_allowed` and `reauth_successful` abort messages.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e9988a348323ac13456996e34fe8)