### PR TITLE
Improve polling performance and entity reliability.

### DIFF
--- a/custom_components/ofoehn_poolpilot/__init__.py
+++ b/custom_components/ofoehn_poolpilot/__init__.py
@@ -10,12 +10,31 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, PLATFORMS, SCAN_INTERVAL, DEFAULT_TIMEOUT
+from .const import (
+    CONF_ENABLE_RAW_SENSORS,
+    CONF_SCAN_INTERVAL,
+    DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+    PLATFORMS,
+    SCAN_INTERVAL,
+    DEFAULT_TIMEOUT,
+)
 from .coordinator import OFoehnApi, OFoehnCoordinator
 from .helpers import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+def _scan_interval_from_options(options: dict) -> timedelta:
+    raw = options.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+    try:
+        seconds = int(raw)
+    except (TypeError, ValueError):
+        seconds = SCAN_INTERVAL
+    seconds = max(MIN_SCAN_INTERVAL, min(MAX_SCAN_INTERVAL, seconds))
+    return timedelta(seconds=seconds)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -44,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         logger=_LOGGER,
         name="ofoehn_poolpilot",
         api=api,
-        update_interval=timedelta(seconds=SCAN_INTERVAL),
+        update_interval=_scan_interval_from_options(entry.options),
         options=entry.options,
     )
     await coordinator.async_config_entry_first_refresh()
@@ -104,4 +123,35 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    await hass.config_entries.async_reload(entry.entry_id)
+    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if data is None:
+        return
+
+    previous_options = dict(data["coordinator"].options)
+    new_options = dict(entry.options)
+    coordinator: OFoehnCoordinator = data["coordinator"]
+
+    reload_needed = previous_options.get(CONF_ENABLE_RAW_SENSORS) != new_options.get(
+        CONF_ENABLE_RAW_SENSORS
+    )
+
+    coordinator.set_options(new_options)
+    coordinator.update_interval = _scan_interval_from_options(new_options)
+
+    if reload_needed:
+        await hass.config_entries.async_reload(entry.entry_id)
+        return
+
+    await coordinator.async_request_refresh()
+
+
+def update_device_info(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Refresh stored device info after coordinator data changes."""
+    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if data is None:
+        return
+    data["device_info"] = build_device_info(
+        data["device_key"],
+        entry.data["host"],
+        data["coordinator"].data or {},
+    )

--- a/custom_components/ofoehn_poolpilot/binary_sensor.py
+++ b/custom_components/ofoehn_poolpilot/binary_sensor.py
@@ -1,39 +1,39 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
-from .helpers import device_info_for_host
+from .helpers import OFoehnEntity, get_donnee_bool
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator: OFoehnCoordinator = data["coordinator"]
-    host = data["host"]
-    connectivity = ConnectivityBinarySensor(coordinator, host)
+    device_key = data["device_key"]
+    device_info = data["device_info"]
+    connectivity = ConnectivityBinarySensor(coordinator, device_key, device_info)
     sensors = [
         connectivity,
-        PumpBinarySensor(coordinator, host),
-        HeatingBinarySensor(coordinator, host),
+        PumpBinarySensor(coordinator, device_key, device_info),
+        HeatingBinarySensor(coordinator, device_key, device_info),
     ]
     async_add_entities(sensors, True)
     data["connectivity_sensor"] = connectivity
 
 
-class ConnectivityBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class ConnectivityBinarySensor(OFoehnEntity, BinarySensorEntity):
     _attr_name = "O'Foehn PoolPilot Connectivity"
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str) -> None:
-        super().__init__(coordinator)
-        self._host = host
-        self._attr_unique_id = f"ofoehn_connectivity_{host}"
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+    ) -> None:
+        super().__init__(coordinator, device_key, device_info)
+        self._attr_unique_id = f"ofoehn_connectivity_{device_key}"
         self._last_check: bool | None = None
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
 
     @property
     def is_on(self) -> bool:
@@ -47,61 +47,50 @@ class ConnectivityBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return self._last_check
 
 
-class PumpBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class PumpBinarySensor(OFoehnEntity, BinarySensorEntity):
     _attr_name = "O'Foehn Pompe"
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str) -> None:
-        super().__init__(coordinator)
-        self._host = host
-        self._attr_unique_id = f"ofoehn_pump_{host}"
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+    ) -> None:
+        super().__init__(coordinator, device_key, device_info)
+        self._attr_unique_id = f"ofoehn_pump_{device_key}"
 
     @property
     def is_on(self) -> bool:
-        idx = self.coordinator.data["indices"].get("pump_idx")
-        if idx is None:
-            fallback = self.coordinator.data.get("pump_on")
-            return False if fallback is None else fallback
-        try:
-            value = self.coordinator.data["super"].get(idx)
-            if value is not None:
-                return float(value) > 0
-        except (TypeError, ValueError):
-            pass
-        fallback = self.coordinator.data.get("pump_on")
-        return False if fallback is None else fallback
+        result = get_donnee_bool(
+            self.coordinator.data,
+            "pump_idx",
+            fallback_key="pump_on",
+            default=False,
+        )
+        return bool(result)
 
 
-class HeatingBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class HeatingBinarySensor(OFoehnEntity, BinarySensorEntity):
     _attr_name = "O'Foehn Chauffage"
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str) -> None:
-        super().__init__(coordinator)
-        self._host = host
-        self._attr_unique_id = f"ofoehn_heating_{host}"
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+    ) -> None:
+        super().__init__(coordinator, device_key, device_info)
+        self._attr_unique_id = f"ofoehn_heating_{device_key}"
 
     @property
     def is_on(self) -> bool:
-        idx = self.coordinator.data["indices"].get("heating_idx")
-        if idx is None:
-            return bool(
-                self.coordinator.data.get("compressor_1_on")
-                or self.coordinator.data.get("compressor_2_on")
-            )
-        try:
-            value = self.coordinator.data["super"].get(idx)
-            if value is not None:
-                return float(value) > 0
-        except (TypeError, ValueError):
-            pass
-        return bool(
-            self.coordinator.data.get("compressor_1_on")
-            or self.coordinator.data.get("compressor_2_on")
+        result = get_donnee_bool(
+            self.coordinator.data,
+            "heating_idx",
+            fallback_key=None,
+            default=None,
         )
+        if result is not None:
+            return result
+        data = self.coordinator.data
+        return bool(data.get("compressor_1_on") or data.get("compressor_2_on"))

--- a/custom_components/ofoehn_poolpilot/climate.py
+++ b/custom_components/ofoehn_poolpilot/climate.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import HVACMode, ClimateEntityFeature
 from homeassistant.const import UnitOfTemperature
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
-from .helpers import device_info_for_host
+from .helpers import OFoehnEntity, get_donnee_bool, get_donnee_float
 
 SUPPORTED_HVAC = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
 
@@ -15,11 +14,12 @@ SUPPORTED_HVAC = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coord: OFoehnCoordinator = data["coordinator"]
-    host = data["host"]
-    async_add_entities([OFoehnClimate(coord, host, entry.entry_id)], True)
+    device_key = data["device_key"]
+    device_info = data["device_info"]
+    async_add_entities([OFoehnClimate(coord, device_key, device_info)], True)
 
 
-class OFoehnClimate(CoordinatorEntity, ClimateEntity):
+class OFoehnClimate(OFoehnEntity, ClimateEntity):
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_hvac_modes = SUPPORTED_HVAC
@@ -27,30 +27,24 @@ class OFoehnClimate(CoordinatorEntity, ClimateEntity):
     _attr_min_temp = 10
     _attr_max_temp = 35
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str):
-        super().__init__(coordinator)
-        self._host = host
-        self._entry_id = entry_id
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._attr_name = "O'Foehn – PAC Piscine"
-        self._attr_unique_id = f"ofoehn_climate_{host}"
+        self._attr_unique_id = f"ofoehn_climate_{device_key}"
 
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
-
-    def _is_power_on(self):
-        idx = self.coordinator.data["indices"].get("power_idx")
-        if idx is None:
-            fallback = self.coordinator.data.get("power_on")
-            return True if fallback is None else fallback
-        try:
-            value = self.coordinator.data["super"].get(idx)
-            if value is not None:
-                return float(value) > 0
-        except Exception:
-            pass
-        fallback = self.coordinator.data.get("power_on")
-        return True if fallback is None else fallback
+    def _is_power_on(self) -> bool:
+        result = get_donnee_bool(
+            self.coordinator.data,
+            "power_idx",
+            fallback_key="power_on",
+            default=True,
+        )
+        return bool(result)
 
     async def _power_on(self):
         if not self._is_power_on():
@@ -64,11 +58,11 @@ class OFoehnClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def current_temperature(self):
-        idx = self.coordinator.data["indices"]["water_in_idx"]
-        value = self.coordinator.data["super"].get(idx)
-        if value is not None:
-            return value
-        return self.coordinator.data.get("water_in")
+        return get_donnee_float(
+            self.coordinator.data,
+            "water_in_idx",
+            fallback_key="water_in",
+        )
 
     @property
     def target_temperature(self):

--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import urlparse
 
+import asyncio
 import voluptuous as vol
 from aiohttp import ClientError, ClientResponseError
 from homeassistant import config_entries
@@ -14,6 +15,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .coordinator import OFoehnApi, parse_accueil_html, parse_donnees
 
 from .const import (
+    CONF_ENABLE_RAW_SENSORS,
+    CONF_SCAN_INTERVAL,
     DOMAIN,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
@@ -22,6 +25,9 @@ from .const import (
     AUTH_QUERY,
     AUTH_COOKIE,
     DEFAULT_INDEX,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+    SCAN_INTERVAL,
 )
 
 AUTH_OPTIONS = [AUTH_NONE, AUTH_BASIC, AUTH_QUERY, AUTH_COOKIE]
@@ -113,8 +119,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         try:
-            raw_super = await api.read_super()
-            raw_accueil = await api.read_accueil()
+            raw_super, raw_accueil = await asyncio.gather(
+                api.read_super(),
+                api.read_accueil(),
+            )
         except ClientResponseError as err:
             if err.status in (401, 403):
                 raise InvalidAuth from err
@@ -257,6 +265,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             schema = vol.Schema(
                 {
                     vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=oi.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
+                    ): vol.All(int, vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL)),
+                    vol.Optional(
+                        CONF_ENABLE_RAW_SENSORS,
+                        default=oi.get(CONF_ENABLE_RAW_SENSORS, False),
+                    ): bool,
+                    vol.Optional(
                         "water_in_idx",
                         default=oi.get("water_in_idx", DEFAULT_INDEX["water_in_idx"]),
                         description=select,
@@ -306,6 +322,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         else:
             schema = vol.Schema(
                 {
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=oi.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
+                    ): vol.All(int, vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL)),
+                    vol.Optional(
+                        CONF_ENABLE_RAW_SENSORS,
+                        default=oi.get(CONF_ENABLE_RAW_SENSORS, False),
+                    ): bool,
                     vol.Optional(
                         "water_in_idx",
                         default=oi.get("water_in_idx", DEFAULT_INDEX["water_in_idx"]),

--- a/custom_components/ofoehn_poolpilot/const.py
+++ b/custom_components/ofoehn_poolpilot/const.py
@@ -3,6 +3,11 @@ DEFAULT_PORT = 80
 DEFAULT_TIMEOUT = 10  # seconds
 PLATFORMS = ["climate", "sensor", "switch", "binary_sensor"]
 SCAN_INTERVAL = 30  # seconds
+MIN_SCAN_INTERVAL = 10
+MAX_SCAN_INTERVAL = 300
+
+CONF_ENABLE_RAW_SENSORS = "enable_raw_sensors"
+CONF_SCAN_INTERVAL = "scan_interval"
 
 # Auth modes
 AUTH_NONE = "none"
@@ -29,5 +34,5 @@ DEFAULT_INDEX = {
     "pump_idx": 10,
     "heating_idx": 11,
     "light_idx": 16,  # accueil.cgi souvent
-    "power_idx": 24   # état alim (selon firmware)
+    "power_idx": 24,  # état alim (selon firmware)
 }

--- a/custom_components/ofoehn_poolpilot/coordinator.py
+++ b/custom_components/ofoehn_poolpilot/coordinator.py
@@ -5,7 +5,8 @@ import html
 import logging
 import re
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any, Callable, Optional
+from urllib.parse import urlencode
 
 from aiohttp import BasicAuth, ClientError, ClientResponseError, ClientSession
 from homeassistant.core import HomeAssistant
@@ -63,9 +64,8 @@ TEMP_PAIR_RE = re.compile(
     re.IGNORECASE,
 )
 
-READ_RETRIES = 0
+READ_RETRIES = 2
 READ_RETRY_DELAY = 0.75
-INTER_REQUEST_DELAY = 0.25
 RETRYABLE_HTTP_STATUSES = {408, 425, 429, 500, 502, 503, 504}
 
 
@@ -330,11 +330,9 @@ class OFoehnApi:
             q = query.copy() if query else {}
             q[self._user_field] = self._username
             q[self._pass_field] = self._password
-            from urllib.parse import urlencode
             sep = "&" if "?" in url else "?"
             url = url + sep + urlencode(q)
         elif query:
-            from urllib.parse import urlencode
             sep = "&" if "?" in url else "?"
             url = url + sep + urlencode(query)
         return url
@@ -463,7 +461,9 @@ class OFoehnApi:
     async def check_connection(self) -> bool:
         """Perform a lightweight request to verify connectivity."""
         try:
-            await self.read_super()
+            if self._auth_mode == AUTH_COOKIE:
+                await self._maybe_login()
+            await self._fetch("GET", ENDPOINTS["accueil"], retries=0)
             return True
         except Exception:
             return False
@@ -679,9 +679,19 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
         super().__init__(hass, logger, name=name, update_interval=update_interval)
         self.api = api
         self.options = options or {}
+        self._cached_indices: dict[str, int] | None = None
+        self._cached_indices_options: dict[str, Any] | None = None
+
+    def set_options(self, options: dict[str, Any]) -> None:
+        """Apply new config entry options and invalidate cached indices."""
+        self.options = options or {}
+        self._cached_indices = None
+        self._cached_indices_options = None
 
     def _build_indices(self) -> dict[str, int]:
-        return {
+        if self._cached_indices is not None and self._cached_indices_options == self.options:
+            return self._cached_indices
+        indices = {
             "water_in_idx": self.options.get("water_in_idx", DEFAULT_INDEX["water_in_idx"]),
             "water_out_idx": self.options.get("water_out_idx", DEFAULT_INDEX["water_out_idx"]),
             "air_idx": self.options.get("air_idx", DEFAULT_INDEX["air_idx"]),
@@ -692,6 +702,9 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
             "light_idx": self.options.get("light_idx", DEFAULT_INDEX["light_idx"]),
             "power_idx": self.options.get("power_idx", DEFAULT_INDEX["power_idx"]),
         }
+        self._cached_indices = indices
+        self._cached_indices_options = dict(self.options)
+        return indices
 
     async def _read_with_fallback(
         self,
@@ -720,30 +733,50 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
             )
             return "", True, str(err)
 
+    async def _read_endpoint(
+        self,
+        *,
+        name: str,
+        reader: Callable[[], Any],
+        previous_raw: str | None,
+        required: bool = False,
+    ) -> tuple[str, bool, str | None]:
+        return await self._read_with_fallback(
+            name=name,
+            reader=reader,
+            previous_raw=previous_raw,
+            required=required,
+        )
+
     async def _async_update_data(self) -> dict:
         previous = self.data if isinstance(self.data, dict) else {}
 
-        sup, sup_stale, sup_error = await self._read_with_fallback(
-            name="super.cgi",
-            reader=self.api.read_super,
-            previous_raw=previous.get("super_raw"),
-            required=True,
+        (
+            (sup, sup_stale, sup_error),
+            (acc, acc_stale, acc_error),
+            (reg, reg_stale, reg_error),
+        ) = await asyncio.gather(
+            self._read_endpoint(
+                name="super.cgi",
+                reader=self.api.read_super,
+                previous_raw=previous.get("super_raw"),
+                required=True,
+            ),
+            self._read_endpoint(
+                name="accueil.cgi",
+                reader=self.api.read_accueil,
+                previous_raw=previous.get("accueil_raw"),
+            ),
+            self._read_endpoint(
+                name="getReg.cgi",
+                reader=self.api.read_reg,
+                previous_raw=previous.get("reg_raw"),
+            ),
         )
-        await asyncio.sleep(INTER_REQUEST_DELAY)
-        acc, acc_stale, acc_error = await self._read_with_fallback(
-            name="accueil.cgi",
-            reader=self.api.read_accueil,
-            previous_raw=previous.get("accueil_raw"),
-        )
-        await asyncio.sleep(INTER_REQUEST_DELAY)
-        reg, reg_stale, reg_error = await self._read_with_fallback(
-            name="getReg.cgi",
-            reader=self.api.read_reg,
-            previous_raw=previous.get("reg_raw"),
-        )
-        self.logger.debug("super_raw: %s", sup)
-        self.logger.debug("accueil_raw: %s", acc)
-        self.logger.debug("reg_raw: %s", reg)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug("super_raw: %s", sup)
+            self.logger.debug("accueil_raw: %s", acc)
+            self.logger.debug("reg_raw: %s", reg)
         page_metadata: dict[str, Any] = {}
         for raw in (sup, acc, reg):
             if not page_metadata:
@@ -751,7 +784,6 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
         parsed_super = parse_super_values(sup)
         parsed_accueil = parse_accueil_html(acc)
         return {
-            **previous,
             "super_raw": sup,
             "accueil_raw": acc,
             "reg_raw": reg,

--- a/custom_components/ofoehn_poolpilot/helpers.py
+++ b/custom_components/ofoehn_poolpilot/helpers.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import OFoehnCoordinator
 
 
 def build_device_info(device_key: str, host: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -36,6 +38,72 @@ def build_device_info(device_key: str, host: str, data: dict[str, Any]) -> dict[
     return info
 
 
-def device_info_for_host(host: str) -> dict[str, Any]:
-    """Backward-compatible device info helper."""
-    return build_device_info(host, host, {})
+def get_donnee_float(
+    data: dict[str, Any],
+    idx_key: str,
+    *,
+    source: str = "super",
+    fallback_key: str | None = None,
+) -> float | None:
+    """Read a numeric DONNEE index with an optional flat fallback key."""
+    indices = data.get("indices") or {}
+    idx = indices.get(idx_key)
+    if idx is not None:
+        bucket = data.get(source) or {}
+        value = bucket.get(idx)
+        if value is not None:
+            return float(value)
+    if fallback_key:
+        fallback = data.get(fallback_key)
+        if fallback is not None:
+            return float(fallback)
+    return None
+
+
+def get_donnee_bool(
+    data: dict[str, Any],
+    idx_key: str,
+    *,
+    source: str = "super",
+    fallback_key: str | None = None,
+    default: bool | None = None,
+) -> bool | None:
+    """Read a boolean DONNEE index with an optional flat fallback key."""
+    indices = data.get("indices") or {}
+    idx = indices.get(idx_key)
+    if idx is not None:
+        bucket = data.get(source) or {}
+        value = bucket.get(idx)
+        if value is not None:
+            try:
+                return float(value) > 0
+            except (TypeError, ValueError):
+                pass
+    if fallback_key is not None:
+        fallback = data.get(fallback_key)
+        if fallback is not None:
+            return bool(fallback)
+    return default
+
+
+class OFoehnEntity(CoordinatorEntity):
+    """Shared base for PoolPilot entities."""
+
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict[str, Any],
+    ) -> None:
+        super().__init__(coordinator)
+        self._device_key = device_key
+        self._device_info = device_info
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return self._device_info
+
+    @property
+    def available(self) -> bool:
+        data = self.coordinator.data or {}
+        return self.coordinator.last_update_success and not data.get("super_stale", False)

--- a/custom_components/ofoehn_poolpilot/sensor.py
+++ b/custom_components/ofoehn_poolpilot/sensor.py
@@ -3,257 +3,267 @@ from __future__ import annotations
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import UnitOfElectricPotential, UnitOfPressure, UnitOfTemperature
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_ENABLE_RAW_SENSORS, DOMAIN
 from .coordinator import OFoehnCoordinator, clean_html_lines, clean_html_text
-from .helpers import device_info_for_host
+from .helpers import OFoehnEntity, get_donnee_float
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coord: OFoehnCoordinator = data["coordinator"]
-    host = data["host"]
+    device_key = data["device_key"]
+    device_info = data["device_info"]
 
-    async_add_entities(
-        [
-            TempSensor(coord, host, entry.entry_id, key="water_in_idx", name="Eau In"),
-            TempSensor(coord, host, entry.entry_id, key="water_out_idx", name="Eau Out"),
-            TempSensor(coord, host, entry.entry_id, key="air_idx", name="Air"),
-            VoltageSensor(coord, host, entry.entry_id, key="voltage_idx", name="Tension"),
-            TempSensor(coord, host, entry.entry_id, key="internal_idx", name="Temp Interne"),
-            SetpointDiffSensor(coord, host, entry.entry_id),
-            RegTextSensor(coord, host, entry.entry_id, key="mode", name="Mode"),
-            RegTextSensor(coord, host, entry.entry_id, key="regulation", name="Régulation"),
-            RegTextSensor(coord, host, entry.entry_id, key="next_action", name="Prochaine action"),
-            RegTextSensor(coord, host, entry.entry_id, key="status", name="État général"),
-            DiagnosticValueSensor(coord, host, entry.entry_id, key="reg_value_1", name="Reg Valeur 1"),
-            DiagnosticValueSensor(coord, host, entry.entry_id, key="reg_value_2", name="Reg Valeur 2"),
-            DiagnosticValueSensor(coord, host, entry.entry_id, key="reg_value_3", name="Reg Valeur 3"),
-            DiagnosticValueSensor(coord, host, entry.entry_id, key="reg_value_4", name="Reg Valeur 4"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="reg_flag_1", name="Reg Flag 1"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="reg_flag_2", name="Reg Flag 2"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="reg_flag_3", name="Reg Flag 3"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="reg_flag_4", name="Reg Flag 4"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="reg_flag_5", name="Reg Flag 5"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="reg_flag_6", name="Reg Flag 6"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="firmware_version", name="Firmware"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="module_version", name="Version Module"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="module_build", name="Build Module"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="module_name", name="Module"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="serial_number", name="Numéro de série"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="mac_address", name="Adresse MAC"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="clock", name="Horloge"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="timers_summary", name="Timers"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="season_stop", name="Mode Saison"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="stopped_state", name="État arrêt"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="heat_state", name="État chauffage"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="signal_level", name="Niveau signal"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="option_1", name="Option 1"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="option_2", name="Option 2"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="config_code", name="Code Config"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="hardware_code", name="Code Hardware"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="webuser_role", name="Rôle WebUser"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="ph_license", name="Licence pH"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="ev_present", name="Présence EV"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="ev_position", name="Position EV"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="balneo_state", name="Balnéo"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="contact_bp1", name="Contact BP1"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="contact_bp2", name="Contact BP2"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="contact_hp1", name="Contact HP1"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="contact_hp2", name="Contact HP2"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="power_state", name="État alimentation"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="pump_state", name="Relai pompe"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="fan_state", name="Relai ventilateur"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="valve_1_state", name="Relai vanne 1"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="compressor_1_state", name="Relai compresseur 1"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="valve_2_state", name="Relai vanne 2"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="compressor_2_state", name="Relai compresseur 2"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="chlorine_state", name="Chlore"),
-            DiagnosticTextSensor(coord, host, entry.entry_id, key="ph_state", name="pH"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="compressor_1_temp", name="Temp Compresseur 1"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="battery_1_temp", name="Temp Batterie 1"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="compressor_2_temp", name="Temp Compresseur 2"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="battery_2_temp", name="Temp Batterie 2"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="ext2_temp", name="Temp Sortie Échangeur"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="gas_temp", name="Temp Gaz"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="superheat", name="Surchauffe"),
-            DiagnosticTemperatureSensor(coord, host, entry.entry_id, key="delta", name="Delta Supervision"),
-            DiagnosticPressureSensor(coord, host, entry.entry_id, key="pressure_1", name="Pression 1"),
-            DiagnosticPressureSensor(coord, host, entry.entry_id, key="pressure_2", name="Pression 2"),
-            RawSensor(coord, host, entry.entry_id, key="super_raw", name="Super Raw"),
-            RawSensor(coord, host, entry.entry_id, key="accueil_raw", name="Accueil Raw"),
-            RawSensor(coord, host, entry.entry_id, key="reg_raw", name="Reg Raw"),
-        ],
-        True,
-    )
+    entities: list[SensorEntity] = [
+        TempSensor(coord, device_key, device_info, key="water_in_idx", name="Eau In"),
+        TempSensor(coord, device_key, device_info, key="water_out_idx", name="Eau Out"),
+        TempSensor(coord, device_key, device_info, key="air_idx", name="Air"),
+        VoltageSensor(coord, device_key, device_info, key="voltage_idx", name="Tension"),
+        TempSensor(coord, device_key, device_info, key="internal_idx", name="Temp Interne"),
+        SetpointDiffSensor(coord, device_key, device_info),
+        RegTextSensor(coord, device_key, device_info, key="mode", name="Mode"),
+        RegTextSensor(coord, device_key, device_info, key="regulation", name="Régulation"),
+        RegTextSensor(coord, device_key, device_info, key="next_action", name="Prochaine action"),
+        RegTextSensor(coord, device_key, device_info, key="status", name="État général"),
+        DiagnosticValueSensor(coord, device_key, device_info, key="reg_value_1", name="Reg Valeur 1"),
+        DiagnosticValueSensor(coord, device_key, device_info, key="reg_value_2", name="Reg Valeur 2"),
+        DiagnosticValueSensor(coord, device_key, device_info, key="reg_value_3", name="Reg Valeur 3"),
+        DiagnosticValueSensor(coord, device_key, device_info, key="reg_value_4", name="Reg Valeur 4"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="reg_flag_1", name="Reg Flag 1"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="reg_flag_2", name="Reg Flag 2"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="reg_flag_3", name="Reg Flag 3"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="reg_flag_4", name="Reg Flag 4"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="reg_flag_5", name="Reg Flag 5"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="reg_flag_6", name="Reg Flag 6"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="firmware_version", name="Firmware"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="module_version", name="Version Module"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="module_build", name="Build Module"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="module_name", name="Module"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="serial_number", name="Numéro de série"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="mac_address", name="Adresse MAC"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="clock", name="Horloge"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="timers_summary", name="Timers"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="season_stop", name="Mode Saison"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="stopped_state", name="État arrêt"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="heat_state", name="État chauffage"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="signal_level", name="Niveau signal"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="option_1", name="Option 1"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="option_2", name="Option 2"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="config_code", name="Code Config"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="hardware_code", name="Code Hardware"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="webuser_role", name="Rôle WebUser"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="ph_license", name="Licence pH"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="ev_present", name="Présence EV"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="ev_position", name="Position EV"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="balneo_state", name="Balnéo"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="contact_bp1", name="Contact BP1"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="contact_bp2", name="Contact BP2"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="contact_hp1", name="Contact HP1"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="contact_hp2", name="Contact HP2"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="power_state", name="État alimentation"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="pump_state", name="Relai pompe"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="fan_state", name="Relai ventilateur"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="valve_1_state", name="Relai vanne 1"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="compressor_1_state", name="Relai compresseur 1"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="valve_2_state", name="Relai vanne 2"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="compressor_2_state", name="Relai compresseur 2"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="chlorine_state", name="Chlore"),
+        DiagnosticTextSensor(coord, device_key, device_info, key="ph_state", name="pH"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="compressor_1_temp", name="Temp Compresseur 1"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="battery_1_temp", name="Temp Batterie 1"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="compressor_2_temp", name="Temp Compresseur 2"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="battery_2_temp", name="Temp Batterie 2"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="ext2_temp", name="Temp Sortie Échangeur"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="gas_temp", name="Temp Gaz"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="superheat", name="Surchauffe"),
+        DiagnosticTemperatureSensor(coord, device_key, device_info, key="delta", name="Delta Supervision"),
+        DiagnosticPressureSensor(coord, device_key, device_info, key="pressure_1", name="Pression 1"),
+        DiagnosticPressureSensor(coord, device_key, device_info, key="pressure_2", name="Pression 2"),
+    ]
+
+    if entry.options.get(CONF_ENABLE_RAW_SENSORS, False):
+        entities.extend(
+            [
+                RawSensor(coord, device_key, device_info, key="super_raw", name="Super Raw"),
+                RawSensor(coord, device_key, device_info, key="accueil_raw", name="Accueil Raw"),
+                RawSensor(coord, device_key, device_info, key="reg_raw", name="Reg Raw"),
+            ]
+        )
+
+    async_add_entities(entities, True)
 
 
-class TempSensor(CoordinatorEntity, SensorEntity):
+class TempSensor(OFoehnEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_{key}_{device_key}"
 
     @property
     def native_value(self):
-        idx = self.coordinator.data["indices"].get(self._key)
-        value = None
-        if idx is not None:
-            value = self.coordinator.data["super"].get(idx)
-            if value is not None:
-                return value
         fallback_map = {
             "water_in_idx": "water_in",
             "water_out_idx": "water_out",
             "air_idx": "air_temp",
             "internal_idx": "internal_temp",
         }
-        fb_key = fallback_map.get(self._key)
-        if fb_key:
-            return self.coordinator.data.get(fb_key)
-        return value
+        return get_donnee_float(
+            self.coordinator.data,
+            self._key,
+            fallback_key=fallback_map.get(self._key),
+        )
 
 
-class VoltageSensor(CoordinatorEntity, SensorEntity):
+class VoltageSensor(OFoehnEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_{key}_{device_key}"
 
     @property
     def native_value(self):
-        idx = self.coordinator.data["indices"].get(self._key)
-        value = None
-        if idx is not None:
-            value = self.coordinator.data["super"].get(idx)
-            if value is not None:
-                return value
-        fallback_map = {"voltage_idx": "voltage"}
-        fb_key = fallback_map.get(self._key)
-        if fb_key:
-            return self.coordinator.data.get(fb_key)
-        return value
+        return get_donnee_float(
+            self.coordinator.data,
+            self._key,
+            fallback_key="voltage",
+        )
 
 
-class DiagnosticTemperatureSensor(CoordinatorEntity, SensorEntity):
+class DiagnosticTemperatureSensor(OFoehnEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 1
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_diag_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_diag_{key}_{device_key}"
 
     @property
     def native_value(self):
         return self.coordinator.data.get(self._key)
 
 
-class DiagnosticValueSensor(CoordinatorEntity, SensorEntity):
+class DiagnosticValueSensor(OFoehnEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 2
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_diag_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_diag_{key}_{device_key}"
 
     @property
     def native_value(self):
         return self.coordinator.data.get(self._key)
 
 
-class DiagnosticPressureSensor(CoordinatorEntity, SensorEntity):
+class DiagnosticPressureSensor(OFoehnEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.PRESSURE
     _attr_native_unit_of_measurement = UnitOfPressure.KPA
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 1
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_diag_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_diag_{key}_{device_key}"
 
     @property
     def native_value(self):
         return self.coordinator.data.get(self._key)
 
 
-class SetpointDiffSensor(CoordinatorEntity, SensorEntity):
+class SetpointDiffSensor(OFoehnEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str):
-        super().__init__(coordinator)
-        self._host = host
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._attr_name = "O'Foehn Écart Consigne"
-        self._attr_unique_id = f"ofoehn_setpoint_diff_{host}"
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_setpoint_diff_{device_key}"
 
     @property
     def native_value(self):
-        water_in = self.coordinator.data.get("water_in")
-        setpoint = self.coordinator.data.get("setpoint")
+        data = self.coordinator.data
+        delta = data.get("delta")
+        if delta is not None:
+            return delta
+        water_in = data.get("water_in")
+        setpoint = data.get("setpoint")
         if water_in is None or setpoint is None:
             return None
         return round(setpoint - water_in, 2)
 
 
-class RegTextSensor(CoordinatorEntity, SensorEntity):
+class RegTextSensor(OFoehnEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_{key}_{device_key}"
 
     @property
     def native_value(self):
@@ -288,48 +298,59 @@ class RegTextSensor(CoordinatorEntity, SensorEntity):
         return value
 
 
-class DiagnosticTextSensor(CoordinatorEntity, SensorEntity):
+class DiagnosticTextSensor(OFoehnEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_diag_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_diag_{key}_{device_key}"
 
     @property
     def native_value(self):
         return self.coordinator.data.get(self._key)
 
 
-class RawSensor(CoordinatorEntity, SensorEntity):
+class RawSensor(OFoehnEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str, entry_id: str, key: str, name: str):
-        super().__init__(coordinator)
+    def __init__(
+        self,
+        coordinator: OFoehnCoordinator,
+        device_key: str,
+        device_info: dict,
+        key: str,
+        name: str,
+    ):
+        super().__init__(coordinator, device_key, device_info)
         self._key = key
         self._attr_name = f"O'Foehn {name}"
-        self._attr_unique_id = f"ofoehn_{key}_{host}"
-        self._host = host
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+        self._attr_unique_id = f"ofoehn_{key}_{device_key}"
 
     @property
     def native_value(self):
         value = self.coordinator.data.get(self._key)
+        if value is None:
+            return None
         preview = clean_html_text(value)
-        self._attr_extra_state_attributes = {
+        return (preview or value)[:255]
+
+    @property
+    def extra_state_attributes(self):
+        value = self.coordinator.data.get(self._key)
+        if value is None:
+            return {}
+        preview = clean_html_text(value)
+        return {
             "raw": value,
             "plain_text": preview,
             "lines": clean_html_lines(value),
         }
-        if value is None:
-            return None
-        return (preview or value)[:255]

--- a/custom_components/ofoehn_poolpilot/switch.py
+++ b/custom_components/ofoehn_poolpilot/switch.py
@@ -1,42 +1,40 @@
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OFoehnCoordinator
-from .helpers import device_info_for_host
+from .helpers import OFoehnEntity, get_donnee_bool
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coord: OFoehnCoordinator = data["coordinator"]
-    host = data["host"]
+    device_key = data["device_key"]
+    device_info = data["device_info"]
 
-    async_add_entities([PowerSwitch(coord, host), PoolLightSwitch(coord, host)], True)
+    async_add_entities(
+        [PowerSwitch(coord, device_key, device_info), PoolLightSwitch(coord, device_key, device_info)],
+        True,
+    )
 
 
-class PowerSwitch(CoordinatorEntity, SwitchEntity):
+class PowerSwitch(OFoehnEntity, SwitchEntity):
     _attr_name = "PAC – Alimentation"
-    def __init__(self, coordinator, host):
-        super().__init__(coordinator)
-        self._host = host
-        self._attr_unique_id = f"ofoehn_power_{host}"
 
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+    def __init__(self, coordinator: OFoehnCoordinator, device_key: str, device_info: dict):
+        super().__init__(coordinator, device_key, device_info)
+        self._attr_unique_id = f"ofoehn_power_{device_key}"
 
     @property
     def is_on(self):
-        idx = self.coordinator.data["indices"]["power_idx"]
-        try:
-            value = self.coordinator.data["super"].get(idx)
-            if value is not None:
-                return float(value) > 0
-        except (TypeError, ValueError):
-            pass
-        return self.coordinator.data.get("power_on")
+        result = get_donnee_bool(
+            self.coordinator.data,
+            "power_idx",
+            fallback_key="power_on",
+            default=True,
+        )
+        return bool(result)
 
     async def async_turn_on(self, **kwargs):
         if not self.is_on:
@@ -49,17 +47,12 @@ class PowerSwitch(CoordinatorEntity, SwitchEntity):
             await self.coordinator.async_request_refresh()
 
 
-class PoolLightSwitch(CoordinatorEntity, SwitchEntity):
+class PoolLightSwitch(OFoehnEntity, SwitchEntity):
     _attr_name = "Éclairage piscine"
 
-    def __init__(self, coordinator: OFoehnCoordinator, host: str):
-        super().__init__(coordinator)
-        self._host = host
-        self._attr_unique_id = f"ofoehn_light_{host}"
-
-    @property
-    def device_info(self):
-        return device_info_for_host(self._host)
+    def __init__(self, coordinator: OFoehnCoordinator, device_key: str, device_info: dict):
+        super().__init__(coordinator, device_key, device_info)
+        self._attr_unique_id = f"ofoehn_light_{device_key}"
 
     @property
     def is_on(self):
@@ -67,9 +60,11 @@ class PoolLightSwitch(CoordinatorEntity, SwitchEntity):
         return self.coordinator.data["accueil"].get(idx, 0) == 1
 
     async def async_turn_on(self, **kwargs):
-        await self.coordinator.api.set_light(True)
-        await self.coordinator.async_request_refresh()
+        if not self.is_on:
+            await self.coordinator.api.set_light(True)
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
-        await self.coordinator.api.set_light(False)
-        await self.coordinator.async_request_refresh()
+        if self.is_on:
+            await self.coordinator.api.set_light(False)
+            await self.coordinator.async_request_refresh()

--- a/custom_components/ofoehn_poolpilot/translations/en.json
+++ b/custom_components/ofoehn_poolpilot/translations/en.json
@@ -38,6 +38,7 @@
         "title": "Advanced options",
         "data": {
           "scan_interval": "Refresh interval (seconds)",
+          "enable_raw_sensors": "Enable Raw sensors (debug)",
           "water_in_idx": "DONNEE# index: Water In",
           "water_out_idx": "DONNEE# index: Water Out",
           "air_idx": "DONNEE# index: Air",

--- a/custom_components/ofoehn_poolpilot/translations/fr.json
+++ b/custom_components/ofoehn_poolpilot/translations/fr.json
@@ -38,6 +38,7 @@
         "title": "Options avancées",
         "data": {
           "scan_interval": "Intervalle de rafraîchissement (secondes)",
+          "enable_raw_sensors": "Activer les capteurs Raw (debug)",
           "water_in_idx": "Index DONNEE# Eau In",
           "water_out_idx": "Index DONNEE# Eau Out",
           "air_idx": "Index DONNEE# Air",


### PR DESCRIPTION
Parallelize CGI reads, add retries and configurable scan interval, stabilize device identity, and make raw debug sensors optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Parallel CGI traffic and coordinator payload assembly no longer merge `**previous` parsed fields, which could change entity values on partial failures; unique IDs keyed by `device_key` instead of host may affect existing Home Assistant entity mappings after upgrade.
> 
> **Overview**
> **Faster, more resilient polling** — the coordinator now fetches `super.cgi`, `accueil.cgi`, and `getReg.cgi` in parallel (setup validation does the same for super/accueil), drops inter-request delays, and enables GET retries (`READ_RETRIES = 2`). Users can set **refresh interval** (10–300s) and **optional raw debug sensors** in advanced options.
> 
> **Options apply without always reloading** — changing scan interval or DONNEE indices updates the coordinator in place and triggers a refresh; only toggling raw sensors forces a config entry reload.
> 
> **Stable device registry and entities** — integrations store `device_key` + `build_device_info()` in `hass.data`; all platforms inherit `OFoehnEntity` with shared `device_info` and availability when `super` data is stale. DONNEE index reads are centralized via `get_donnee_float` / `get_donnee_bool`. Connectivity checks use a lightweight `accueil` GET instead of full `read_super`. Light/power switches skip redundant API calls when state is already correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e2289c807f7009f5b0c9f48a797f21aec0272c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->