### PR TITLE
Fix config flow loops and reduce polling noise when the PAC is unreac…

### DIFF
--- a/custom_components/ofoehn_poolpilot/__init__.py
+++ b/custom_components/ofoehn_poolpilot/__init__.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 
 from aiohttp import ClientSession
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -66,7 +68,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=_scan_interval_from_options(entry.options),
         options=entry.options,
     )
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady as err:
+        _LOGGER.warning(
+            "Initial poll failed for %s — integration stays configurable: %s",
+            entry.data["host"],
+            err,
+        )
 
     entry_updates = dict(entry.data)
     changed = False

--- a/custom_components/ofoehn_poolpilot/config_flow.py
+++ b/custom_components/ofoehn_poolpilot/config_flow.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from urllib.parse import urlparse
 
-import asyncio
 import voluptuous as vol
 from aiohttp import ClientError, ClientResponseError
 from homeassistant import config_entries
@@ -17,6 +17,8 @@ from .coordinator import OFoehnApi, parse_accueil_html, parse_donnees
 from .const import (
     CONF_ENABLE_RAW_SENSORS,
     CONF_SCAN_INTERVAL,
+    CONFIG_FLOW_TIMEOUT,
+    CONFIG_FLOW_VALIDATION_MAX,
     DOMAIN,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
@@ -49,8 +51,22 @@ class MissingAuth(HomeAssistantError):
     """Error to indicate credentials are required."""
 
 
+class ConnectionTimeout(HomeAssistantError):
+    """Error to indicate the device did not respond in time."""
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
+
+    @staticmethod
+    def _validation_timeout(user_timeout: int) -> int:
+        return min(max(int(user_timeout), 3), CONFIG_FLOW_TIMEOUT)
+
+    async def _async_probe_device(self, api: OFoehnApi) -> tuple[str, str]:
+        await api.prepare_for_reads()
+        raw_super = await api.read_super(retries=0)
+        raw_accueil = await api.read_accueil(retries=0)
+        return raw_super, raw_accueil
 
     def _normalize_host(self, value: str) -> tuple[str, int | None]:
         raw = value.strip()
@@ -104,6 +120,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_validate_input(self, user_input: dict[str, Any]) -> dict[str, Any]:
         data = self._prepare_user_input(user_input)
         session = async_get_clientsession(self.hass)
+        probe_timeout = self._validation_timeout(data.get("timeout", DEFAULT_TIMEOUT))
         api = OFoehnApi(
             host=data[CONF_HOST],
             port=data.get(CONF_PORT, DEFAULT_PORT),
@@ -115,14 +132,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             login_method=data.get("login_method", "POST"),
             user_field=data.get("user_field", "user"),
             pass_field=data.get("pass_field", "pass"),
-            timeout=data.get("timeout", DEFAULT_TIMEOUT),
+            timeout=probe_timeout,
         )
 
         try:
-            raw_super, raw_accueil = await asyncio.gather(
-                api.read_super(),
-                api.read_accueil(),
+            raw_super, raw_accueil = await asyncio.wait_for(
+                self._async_probe_device(api),
+                timeout=CONFIG_FLOW_VALIDATION_MAX,
             )
+        except TimeoutError as err:
+            raise ConnectionTimeout from err
         except ClientResponseError as err:
             if err.status in (401, 403):
                 raise InvalidAuth from err
@@ -167,9 +186,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_user(self, user_input=None):
-        errors = {}
-        existing_entries = self._async_current_entries()
-        existing_entry = existing_entries[0] if existing_entries else None
+        return await self._async_step_connection(user_input, step_id="user")
+
+    async def async_step_reconfigure(self, user_input=None):
+        return await self._async_step_connection(user_input, step_id="reconfigure")
+
+    async def _async_step_connection(self, user_input=None, *, step_id: str = "user"):
+        errors: dict[str, str] = {}
+        existing_entry = None
+        reconfigure_entry_id = self.context.get("entry_id")
+        if reconfigure_entry_id:
+            existing_entry = self.hass.config_entries.async_get_entry(reconfigure_entry_id)
+        if existing_entry is None:
+            existing_entries = self._async_current_entries()
+            existing_entry = existing_entries[0] if existing_entries else None
 
         if user_input is not None:
             try:
@@ -180,6 +210,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "missing_auth"
             except InvalidHost:
                 errors["base"] = "invalid_host"
+            except ConnectionTimeout:
+                errors["base"] = "timeout"
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -205,11 +237,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data=prepared_input,
                 )
 
-        defaults = dict(existing_entry.data) if existing_entry else dict(user_input or {})
+        if user_input is not None:
+            defaults = dict(user_input)
+        elif existing_entry:
+            defaults = dict(existing_entry.data)
+        else:
+            defaults = {}
         if not defaults.get(CONF_HOST):
             defaults[CONF_HOST] = ""
         return self.async_show_form(
-            step_id="user",
+            step_id=step_id,
             data_schema=self._build_user_schema(defaults),
             errors=errors,
         )
@@ -241,12 +278,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             login_method=self.config_entry.data.get("login_method", "POST"),
             user_field=self.config_entry.data.get("user_field", "user"),
             pass_field=self.config_entry.data.get("pass_field", "pass"),
-            timeout=self.config_entry.data.get("timeout", DEFAULT_TIMEOUT),
+            timeout=min(
+                self.config_entry.data.get("timeout", DEFAULT_TIMEOUT),
+                CONFIG_FLOW_TIMEOUT,
+            ),
         )
 
         try:
-            raw = await api.read_super()
+            raw = await asyncio.wait_for(
+                api.read_super(retries=0),
+                timeout=CONFIG_FLOW_VALIDATION_MAX,
+            )
             donnees = parse_donnees(raw)
+        except TimeoutError:
+            errors["base"] = "timeout"
+            donnees = {}
         except Exception:
             errors["base"] = "cannot_connect"
             donnees = {}

--- a/custom_components/ofoehn_poolpilot/const.py
+++ b/custom_components/ofoehn_poolpilot/const.py
@@ -1,6 +1,8 @@
 DOMAIN = "ofoehn_poolpilot"
 DEFAULT_PORT = 80
 DEFAULT_TIMEOUT = 10  # seconds
+CONFIG_FLOW_TIMEOUT = 5  # seconds — shorter timeout during setup/reconfigure
+CONFIG_FLOW_VALIDATION_MAX = 12  # hard cap for the whole config-flow probe
 PLATFORMS = ["climate", "sensor", "switch", "binary_sensor"]
 SCAN_INTERVAL = 30  # seconds
 MIN_SCAN_INTERVAL = 10

--- a/custom_components/ofoehn_poolpilot/coordinator.py
+++ b/custom_components/ofoehn_poolpilot/coordinator.py
@@ -64,9 +64,11 @@ TEMP_PAIR_RE = re.compile(
     re.IGNORECASE,
 )
 
-READ_RETRIES = 2
+READ_RETRIES = 1
 READ_RETRY_DELAY = 0.75
+INTER_REQUEST_DELAY = 0.15
 RETRYABLE_HTTP_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+AUTH_ERROR_STATUSES = {401, 403}
 
 
 def clean_html_text(raw: str | None) -> str:
@@ -323,6 +325,13 @@ class OFoehnApi:
         self._basic_auth = BasicAuth(username, password) if (auth_mode == AUTH_BASIC and username) else None
         self._timeout = timeout
         self._cookie_logged_in = False
+        self._request_lock = asyncio.Lock()
+        self._login_lock = asyncio.Lock()
+
+    async def prepare_for_reads(self) -> None:
+        """Ensure auth is ready before a polling batch."""
+        if self._auth_mode == AUTH_COOKIE:
+            await self._maybe_login()
 
     def _url(self, path: str, query: dict[str, Any] | None = None) -> str:
         url = self._base + path
@@ -340,21 +349,22 @@ class OFoehnApi:
     async def _maybe_login(self, *, force: bool = False) -> None:
         if self._auth_mode != AUTH_COOKIE:
             return
-        if self._cookie_logged_in and not force:
-            return
-        data = {self._user_field: self._username or "", self._pass_field: self._password or ""}
-        url = self._base + self._login_path
-        try:
-            if self._login_method == "GET":
-                async with self._session.get(url, params=data, timeout=self._timeout) as resp:
-                    resp.raise_for_status()
-            else:
-                async with self._session.post(url, data=data, timeout=self._timeout) as resp:
-                    resp.raise_for_status()
-        except Exception:
-            self._cookie_logged_in = False
-            raise
-        self._cookie_logged_in = True
+        async with self._login_lock:
+            if self._cookie_logged_in and not force:
+                return
+            data = {self._user_field: self._username or "", self._pass_field: self._password or ""}
+            url = self._base + self._login_path
+            try:
+                if self._login_method == "GET":
+                    async with self._session.get(url, params=data, timeout=self._timeout) as resp:
+                        resp.raise_for_status()
+                else:
+                    async with self._session.post(url, data=data, timeout=self._timeout) as resp:
+                        resp.raise_for_status()
+            except Exception:
+                self._cookie_logged_in = False
+                raise
+            self._cookie_logged_in = True
 
     async def _fetch(
         self,
@@ -365,82 +375,101 @@ class OFoehnApi:
         query: dict[str, Any] | None = None,
         retries: int = 0,
     ) -> str:
-        url = self._url(path, query=query)
-        auth_retry_done = False
-        attempt = 0
+        async with self._request_lock:
+            url = self._url(path, query=query)
+            auth_retry_done = False
+            attempt = 0
 
-        while attempt <= retries:
-            try:
-                if method == "GET":
-                    async with self._session.get(url, timeout=self._timeout, auth=self._basic_auth) as resp:
+            while attempt <= retries:
+                try:
+                    if method == "GET":
+                        async with self._session.get(url, timeout=self._timeout, auth=self._basic_auth) as resp:
+                            resp.raise_for_status()
+                            return await resp.text()
+
+                    payload = data
+                    if self._auth_mode == AUTH_QUERY and self._username and self._password:
+                        if isinstance(payload, dict) or payload is None:
+                            payload = payload.copy() if payload else {}
+                            payload[self._user_field] = self._username
+                            payload[self._pass_field] = self._password
+                    async with self._session.post(
+                        url,
+                        data=payload or {},
+                        timeout=self._timeout,
+                        auth=self._basic_auth,
+                    ) as resp:
                         resp.raise_for_status()
                         return await resp.text()
+                except ClientResponseError as err:
+                    if (
+                        err.status in AUTH_ERROR_STATUSES
+                        and self._auth_mode == AUTH_COOKIE
+                        and not auth_retry_done
+                    ):
+                        self._cookie_logged_in = False
+                        await self._maybe_login(force=True)
+                        auth_retry_done = True
+                        continue
+                    if err.status in AUTH_ERROR_STATUSES:
+                        raise
+                    if method != "GET" or attempt >= retries or err.status not in RETRYABLE_HTTP_STATUSES:
+                        raise
+                    attempt += 1
+                    delay = READ_RETRY_DELAY * attempt
+                    _LOGGER.debug(
+                        "Read %s failed with HTTP %s, retrying in %.2fs (%s/%s)",
+                        path,
+                        err.status,
+                        delay,
+                        attempt,
+                        retries,
+                    )
+                    await asyncio.sleep(delay)
+                except (ClientError, asyncio.TimeoutError, OSError) as err:
+                    if method != "GET" or attempt >= retries:
+                        raise
+                    attempt += 1
+                    delay = READ_RETRY_DELAY * attempt
+                    _LOGGER.debug(
+                        "Read %s failed (%s), retrying in %.2fs (%s/%s)",
+                        path,
+                        err,
+                        delay,
+                        attempt,
+                        retries,
+                    )
+                    await asyncio.sleep(delay)
 
-                payload = data
-                if self._auth_mode == AUTH_QUERY and self._username and self._password:
-                    if isinstance(payload, dict) or payload is None:
-                        payload = payload.copy() if payload else {}
-                        payload[self._user_field] = self._username
-                        payload[self._pass_field] = self._password
-                async with self._session.post(
-                    url,
-                    data=payload or {},
-                    timeout=self._timeout,
-                    auth=self._basic_auth,
-                ) as resp:
-                    resp.raise_for_status()
-                    return await resp.text()
-            except ClientResponseError as err:
-                if err.status in (401, 403) and self._auth_mode == AUTH_COOKIE and not auth_retry_done:
-                    self._cookie_logged_in = False
-                    await self._maybe_login(force=True)
-                    auth_retry_done = True
-                    continue
-                if method != "GET" or attempt >= retries or err.status not in RETRYABLE_HTTP_STATUSES:
-                    raise
-                attempt += 1
-                delay = READ_RETRY_DELAY * attempt
-                _LOGGER.warning(
-                    "Read %s failed with HTTP %s, retrying in %.2fs (%s/%s)",
-                    path,
-                    err.status,
-                    delay,
-                    attempt,
-                    retries,
-                )
-                await asyncio.sleep(delay)
-            except (ClientError, asyncio.TimeoutError, OSError) as err:
-                if method != "GET" or attempt >= retries:
-                    raise
-                attempt += 1
-                delay = READ_RETRY_DELAY * attempt
-                _LOGGER.warning(
-                    "Read %s failed (%s), retrying in %.2fs (%s/%s)",
-                    path,
-                    err,
-                    delay,
-                    attempt,
-                    retries,
-                )
-                await asyncio.sleep(delay)
-
-        raise UpdateFailed(f"Unable to read {path}")
+            raise UpdateFailed(f"Unable to read {path}")
 
     # Reads
-    async def read_super(self) -> str:
+    async def read_super(self, *, retries: int | None = None) -> str:
         if self._auth_mode == AUTH_COOKIE:
             await self._maybe_login()
-        return await self._fetch("GET", ENDPOINTS["super"], retries=READ_RETRIES)
+        return await self._fetch(
+            "GET",
+            ENDPOINTS["super"],
+            retries=READ_RETRIES if retries is None else retries,
+        )
 
-    async def read_accueil(self) -> str:
+    async def read_accueil(self, *, retries: int | None = None) -> str:
         if self._auth_mode == AUTH_COOKIE:
             await self._maybe_login()
-        return await self._fetch("GET", ENDPOINTS["accueil"], retries=READ_RETRIES)
+        return await self._fetch(
+            "GET",
+            ENDPOINTS["accueil"],
+            retries=READ_RETRIES if retries is None else retries,
+        )
 
-    async def read_reg(self) -> str:
+    async def read_reg(self, *, retries: int | None = None) -> str:
         if self._auth_mode == AUTH_COOKIE:
             await self._maybe_login()
-        return await self._fetch("GET", ENDPOINTS["reg_get"], retries=READ_RETRIES)
+        return await self._fetch(
+            "GET",
+            ENDPOINTS["reg_get"],
+            retries=READ_RETRIES if retries is None else retries,
+        )
 
     # Writes
     async def set_mode(self, mode: str) -> None:
@@ -461,9 +490,8 @@ class OFoehnApi:
     async def check_connection(self) -> bool:
         """Perform a lightweight request to verify connectivity."""
         try:
-            if self._auth_mode == AUTH_COOKIE:
-                await self._maybe_login()
-            await self._fetch("GET", ENDPOINTS["accueil"], retries=0)
+            await self.prepare_for_reads()
+            await self._fetch("GET", ENDPOINTS["super"], retries=0)
             return True
         except Exception:
             return False
@@ -681,6 +709,7 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
         self.options = options or {}
         self._cached_indices: dict[str, int] | None = None
         self._cached_indices_options: dict[str, Any] | None = None
+        self._stale_warned: set[str] = set()
 
     def set_options(self, options: dict[str, Any]) -> None:
         """Apply new config entry options and invalidate cached indices."""
@@ -715,22 +744,40 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
         required: bool = False,
     ) -> tuple[str, bool, str | None]:
         try:
-            return await reader(), False, None
+            result = await reader()
+            self._stale_warned.discard(name)
+            return result, False, None
         except Exception as err:
             if previous_raw:
-                self.logger.warning(
-                    "Read %s failed, reusing the last valid payload: %s",
-                    name,
-                    err,
-                )
+                if name not in self._stale_warned:
+                    self.logger.warning(
+                        "Read %s failed, reusing the last valid payload: %s",
+                        name,
+                        err,
+                    )
+                    self._stale_warned.add(name)
+                else:
+                    self.logger.debug(
+                        "Read %s still failing, reusing cached payload: %s",
+                        name,
+                        err,
+                    )
                 return previous_raw, True, str(err)
             if required:
                 raise UpdateFailed(f"Unable to refresh {name}: {err}") from err
-            self.logger.warning(
-                "Read %s failed with no cached payload available: %s",
-                name,
-                err,
-            )
+            if name not in self._stale_warned:
+                self.logger.warning(
+                    "Read %s failed with no cached payload available: %s",
+                    name,
+                    err,
+                )
+                self._stale_warned.add(name)
+            else:
+                self.logger.debug(
+                    "Read %s still failing with no cached payload: %s",
+                    name,
+                    err,
+                )
             return "", True, str(err)
 
     async def _read_endpoint(
@@ -751,27 +798,25 @@ class OFoehnCoordinator(DataUpdateCoordinator[dict]):
     async def _async_update_data(self) -> dict:
         previous = self.data if isinstance(self.data, dict) else {}
 
-        (
-            (sup, sup_stale, sup_error),
-            (acc, acc_stale, acc_error),
-            (reg, reg_stale, reg_error),
-        ) = await asyncio.gather(
-            self._read_endpoint(
-                name="super.cgi",
-                reader=self.api.read_super,
-                previous_raw=previous.get("super_raw"),
-                required=True,
-            ),
-            self._read_endpoint(
-                name="accueil.cgi",
-                reader=self.api.read_accueil,
-                previous_raw=previous.get("accueil_raw"),
-            ),
-            self._read_endpoint(
-                name="getReg.cgi",
-                reader=self.api.read_reg,
-                previous_raw=previous.get("reg_raw"),
-            ),
+        await self.api.prepare_for_reads()
+
+        sup, sup_stale, sup_error = await self._read_endpoint(
+            name="super.cgi",
+            reader=self.api.read_super,
+            previous_raw=previous.get("super_raw"),
+            required=True,
+        )
+        await asyncio.sleep(INTER_REQUEST_DELAY)
+        acc, acc_stale, acc_error = await self._read_endpoint(
+            name="accueil.cgi",
+            reader=self.api.read_accueil,
+            previous_raw=previous.get("accueil_raw"),
+        )
+        await asyncio.sleep(INTER_REQUEST_DELAY)
+        reg, reg_stale, reg_error = await self._read_endpoint(
+            name="getReg.cgi",
+            reader=self.api.read_reg,
+            previous_raw=previous.get("reg_raw"),
         )
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug("super_raw: %s", sup)

--- a/custom_components/ofoehn_poolpilot/translations/en.json
+++ b/custom_components/ofoehn_poolpilot/translations/en.json
@@ -4,7 +4,23 @@
     "step": {
       "user": {
         "title": "Connect to O'Foehn heat pump",
-        "description": "Enter the heat pump's real IP address and choose the authentication mode if required. If a configuration already exists, this form will update it.",
+        "description": "Enter the heat pump's real IP address (e.g. 192.168.2.151) and choose authentication if required. Connection is tested with a short timeout (5 s max).",
+        "data": {
+          "host": "IP address",
+          "port": "Port",
+          "auth_mode": "Authentication mode",
+          "username": "Username",
+          "password": "Password",
+          "login_path": "Login path (COOKIE)",
+          "login_method": "Login method (COOKIE)",
+          "user_field": "Username field name",
+          "pass_field": "Password field name",
+          "timeout": "Timeout (seconds)"
+        }
+      },
+      "reconfigure": {
+        "title": "Update O'Foehn connection",
+        "description": "Fix the IP address or authentication. Connection is tested with a short timeout (5 s max).",
         "data": {
           "host": "IP address",
           "port": "Port",
@@ -29,6 +45,7 @@
       "invalid_auth": "Authentication was rejected by the heat pump.",
       "invalid_host": "Invalid IP address or hostname.",
       "missing_auth": "Username and password are required for this mode.",
+      "timeout": "The heat pump did not respond in time. Check the IP address and network.",
       "unknown": "Unexpected error."
     }
   },

--- a/custom_components/ofoehn_poolpilot/translations/fr.json
+++ b/custom_components/ofoehn_poolpilot/translations/fr.json
@@ -4,7 +4,23 @@
     "step": {
       "user": {
         "title": "Connexion à la PAC O'Foehn",
-        "description": "Entrez l'adresse IP réelle de la PAC et choisissez le mode d'authentification si nécessaire. Si une configuration existe déjà, ce formulaire la mettra à jour.",
+        "description": "Entrez l'adresse IP réelle de la PAC (ex. 192.168.2.151) et choisissez le mode d'authentification si nécessaire. La connexion est testée avec un délai court (5 s max).",
+        "data": {
+          "host": "Adresse IP",
+          "port": "Port",
+          "auth_mode": "Mode d'authentification",
+          "username": "Nom d'utilisateur",
+          "password": "Mot de passe",
+          "login_path": "Chemin de login (COOKIE)",
+          "login_method": "Méthode de login (COOKIE)",
+          "user_field": "Nom du champ utilisateur",
+          "pass_field": "Nom du champ mot de passe",
+          "timeout": "Délai d'expiration (secondes)"
+        }
+      },
+      "reconfigure": {
+        "title": "Modifier la connexion O'Foehn",
+        "description": "Corrigez l'adresse IP ou l'authentification. La connexion est testée avec un délai court (5 s max).",
         "data": {
           "host": "Adresse IP",
           "port": "Port",
@@ -29,6 +45,7 @@
       "invalid_auth": "Authentification refusée par la PAC.",
       "invalid_host": "Adresse IP ou nom d'hôte invalide.",
       "missing_auth": "Nom d'utilisateur et mot de passe requis pour ce mode.",
+      "timeout": "La PAC ne répond pas (délai dépassé). Vérifiez l'adresse IP et le réseau.",
       "unknown": "Erreur inattendue."
     }
   },


### PR DESCRIPTION
…hable.

Preserve entered IP on validation errors, add short setup timeouts, keep the integration configurable after failed startup, and serialize device reads with quieter retries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Polling is now sequential with fewer retries, which may slow updates or change failure behavior on flaky networks; setup continues without initial data, so entities may be unavailable until the device responds.
> 
> **Overview**
> Improves setup and reconfigure when the heat pump is slow or offline: validation uses **capped timeouts** (5 s per request, 12 s overall), **sequential** device probes with no retries, and a dedicated **timeout** error in EN/FR. A shared connection step adds **reconfigure** support and **keeps submitted values** on failed validation so users are not stuck in empty forms.
> 
> **Startup** no longer aborts on the first failed poll—`ConfigEntryNotReady` is logged and the entry stays loaded so IP/auth can be fixed via reconfigure.
> 
> **Runtime polling** serializes HTTP via locks, reads `super` → `accueil` → `getReg` with a short gap instead of parallel `gather`, cuts default read retries, downgrades repeat failure logs to debug, and warns once per endpoint when reusing stale payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518cab5503d32b657745673213a403e80f4234a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->